### PR TITLE
Fix Pexels search, broken test client, and misleading docs (closes #7, #8, #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,45 +85,59 @@ Add Stocky to your MCP client configuration:
 <p><em>Find the perfect image for your project</em></p>
 </div>
 
+Stocky exposes `search_stock_images`, `get_image_details`, and `download_image`
+as **MCP tools**. They are not Python functions you import and call — your MCP
+client (e.g. Claude Desktop) invokes them on your behalf when you ask in
+natural language. The parameters below map to each tool's arguments.
+
 ### Searching for Images
 
-Search across all providers:
-```python
-results = await search_stock_images("sunset beach")
-```
+Just ask your assistant, for example:
 
-Search specific providers:
-```python
-results = await search_stock_images(
-    query="mountain landscape",
-    providers=["pexels", "unsplash"],
-    per_page=30,
-    page=1
-)
+> Search stock photos for a sunset beach.
+
+> Find 30 mountain landscape photos from Pexels and Unsplash.
+
+These map to the `search_stock_images` tool. The arguments a client sends look
+like:
+
+```json
+{
+  "query": "mountain landscape",
+  "providers": ["pexels", "unsplash"],
+  "per_page": 30,
+  "page": 1
+}
 ```
 
 ### Getting Image Details
 
-```python
-details = await get_image_details("unsplash_abc123xyz")
-```
+> Get the details for image `unsplash_abc123xyz`.
+
+Maps to `get_image_details` with `{"image_id": "unsplash_abc123xyz"}`.
 
 ### Downloading Images
 
-```python
-# Download and save to disk
-result = await download_image(
-    image_id="pexels_123456", 
-    size="medium", 
-    output_path="/path/to/save.jpg"
-)
+> Download `pexels_123456` at medium size to /path/to/save.jpg.
 
-# Get base64-encoded image data
-result = await download_image(
-    image_id="unsplash_abc123", 
-    size="original"
-)
+Maps to `download_image`:
+
+```json
+{
+  "image_id": "pexels_123456",
+  "size": "medium",
+  "output_path": "/path/to/save.jpg"
+}
 ```
+
+If `output_path` is omitted, the tool returns base64-encoded image data instead
+of writing a file.
+
+### Calling the tools programmatically
+
+To drive the tools from Python, connect to the server through an MCP client
+session over stdio rather than importing these names. See
+[`test_mcp_client.py`](test_mcp_client.py) for a complete, runnable example.
 
 ## 🛠️ Tools Documentation
 
@@ -198,9 +212,11 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 ### Common Issues
 
 **"API key not found" error**
-- Ensure your `.env` file exists and contains valid API keys
-- Check that environment variables are properly loaded
-- Verify API key names match exactly (case-sensitive)
+- Set the keys in the `env` block of your MCP client configuration (see
+  [MCP Client Configuration](#-mcp-client-configuration)) — the server reads
+  them from its environment and does not load a `.env` file on its own
+- Verify API key names match exactly (case-sensitive): `PEXELS_API_KEY`,
+  `UNSPLASH_ACCESS_KEY`
 
 **No results returned**
 - Try different search terms

--- a/stocky_mcp.py
+++ b/stocky_mcp.py
@@ -109,8 +109,8 @@ class PexelsProvider(StockImageProvider):
         """Async context manager exit."""
         self.session = None
 
-    def search(self, query: str, per_page: int = 20, page: int = 1,
-               **kwargs) -> List[ImageResult]:
+    async def search(self, query: str, per_page: int = 20, page: int = 1,
+                     **kwargs) -> List[ImageResult]:
         """Search Pexels for images."""
         if not self.session:
             raise RuntimeError(
@@ -118,7 +118,11 @@ class PexelsProvider(StockImageProvider):
             )
 
         url = "https://api.pexels.com/v1/search"
-        headers = {"Authorization": self.api_key}
+        headers = {
+            "Authorization": self.api_key,
+            # Pexels' Cloudflare rejects requests with no User-Agent (403)
+            "User-Agent": "stocky-mcp/1.0",
+        }
         params = {
             "query": query,
             "per_page": per_page,
@@ -151,9 +155,6 @@ class PexelsProvider(StockImageProvider):
             # Parse JSON response
             response_data = buffer.getvalue().decode('utf-8')
             data = json.loads(response_data)
-        except (pycurl.error, json.JSONDecodeError) as e:
-            logger.error(f"Pexels API error: {e}")
-            return []
 
             results = []
             for photo in data.get("photos", []):
@@ -177,11 +178,12 @@ class PexelsProvider(StockImageProvider):
                     tags=[photo.get("alt", "").lower()]
                     if photo.get("alt") else []
                 ))
-        except pycurl.error as e:
+            return results
+        except (pycurl.error, json.JSONDecodeError) as e:
             logger.error(f"Pexels API error: {e}")
             return []
-            
-    def get_details(self, image_id: str) -> Optional[ImageResult]:  # noqa: E501
+
+    async def get_details(self, image_id: str) -> Optional[ImageResult]:  # noqa: E501
         """Get details for a specific Pexels image."""
         if not self.session:
             raise RuntimeError(
@@ -191,7 +193,11 @@ class PexelsProvider(StockImageProvider):
         # Extract ID from our prefixed ID
         pexels_id = image_id.replace("pexels_", "")
         url = f"https://api.pexels.com/v1/photos/{pexels_id}"
-        headers = {"Authorization": self.api_key}
+        headers = {
+            "Authorization": self.api_key,
+            # Pexels' Cloudflare rejects requests with no User-Agent (403)
+            "User-Agent": "stocky-mcp/1.0",
+        }
 
         try:
             # Use pycurl to make the request

--- a/test_mcp_client.py
+++ b/test_mcp_client.py
@@ -1,137 +1,131 @@
 #!/usr/bin/env python3
 """
 Test client for Stocky MCP server.
-This script tests the functionality of the Stocky MCP server by making requests to it.
+
+Spawns the Stocky server over stdio (the same transport MCP clients such as
+Claude Desktop use), performs the MCP handshake, and exercises the tools and
+the help resource.
+
+Requires PEXELS_API_KEY and/or UNSPLASH_ACCESS_KEY in the environment for the
+search/details tests to return results; without them the server still starts
+and the handshake/tool-listing checks run.
+
+Usage:
+    PEXELS_API_KEY=... UNSPLASH_ACCESS_KEY=... python test_mcp_client.py
 """
 
 import asyncio
 import json
-import subprocess
+import os
 import sys
 from pathlib import Path
 
-# Import the correct client classes
-from mcp.client.session import ClientSession
-from mcp.types import Tool, Resource
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+SERVER_PATH = Path(__file__).resolve().parent / "stocky_mcp.py"
 
 
-async def start_server_process():
-    """Start the MCP server process in the background."""
-    # This is just a simulation since we already have a server running
-    print("Note: Using existing MCP server process")
-    return None  # We're not actually starting a new process
+def _tool_payload(result):
+    """Extract the JSON payload returned by a tool call.
+
+    FastMCP serializes a tool's return value into the result's text content
+    (and, on newer versions, structuredContent). Prefer the structured value
+    when present, otherwise parse the first text block.
+    """
+    structured = getattr(result, "structuredContent", None)
+    if structured:
+        # FastMCP wraps a plain return value under a single "result" key.
+        if isinstance(structured, dict) and set(structured) == {"result"}:
+            return structured["result"]
+        return structured
+    for block in result.content:
+        text = getattr(block, "text", None)
+        if text:
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                return text
+    return None
 
 
-async def test_search_images():
-    """Test the search_stock_images tool."""
-    print("Testing search_stock_images tool...")
-    
-    # Create a client session for the local MCP server
-    session = ClientSession("stocky", "http://localhost:8080")
+async def run_tests(session: ClientSession) -> None:
+    # Handshake
     await session.initialize()
-    
-    try:
-        # Get available tools
-        tools = await session.list_tools()
-        print(f"Available tools: {[tool.name for tool in tools]}")
-        
-        # Test search with default parameters
-        print("\nSearching for 'mountain landscape'...")
-        result = await session.call_tool(
-            "search_stock_images", 
-            {"query": "mountain landscape"}
-        )
-        
-        # Print the number of results and first result details
-        if isinstance(result, list):
-            print(f"Found {len(result)} images")
-            if result:
-                first_image = result[0]
-                print("\nFirst image details:")
-                print(f"ID: {first_image.get('id')}")
-                print(f"Title: {first_image.get('title')}")
-                print(f"Source: {first_image.get('source')}")
-                print(f"URL: {first_image.get('url')}")
-        else:
-            print(f"Error: {result}")
-    finally:
-        await session.shutdown()
+    print("Initialized session with Stocky server")
 
+    # Tools
+    tools = (await session.list_tools()).tools
+    tool_names = [t.name for t in tools]
+    print(f"Available tools: {tool_names}")
+    assert "search_stock_images" in tool_names, "search_stock_images missing"
 
-async def test_get_image_details():
-    """Test the get_image_details tool."""
-    print("\nTesting get_image_details tool...")
-    
-    # Create a client session for the local MCP server
-    session = ClientSession("stocky", "http://localhost:8080")
-    await session.initialize()
-    
-    try:
-        # First search to get an image ID
-        search_result = await session.call_tool(
-            "search_stock_images", 
-            {"query": "sunset", "per_page": 1}
+    have_keys = bool(
+        os.getenv("PEXELS_API_KEY") or os.getenv("UNSPLASH_ACCESS_KEY")
+    )
+    if not have_keys:
+        print(
+            "\nNo API keys set - skipping live search/details tests "
+            "(handshake and tool listing passed)."
         )
-        
-        if isinstance(search_result, list) and search_result:
-            image_id = search_result[0].get('id')
-            print(f"Getting details for image ID: {image_id}")
-            
-            # Get details for the first image
-            details = await session.call_tool(
-                "get_image_details", 
-                {"image_id": image_id}
+        return
+
+    # search_stock_images
+    print("\nSearching for 'mountain landscape'...")
+    search = _tool_payload(
+        await session.call_tool(
+            "search_stock_images", {"query": "mountain landscape", "per_page": 3}
+        )
+    )
+    results = search.get("results", []) if isinstance(search, dict) else []
+    print(f"Found {len(results)} images")
+    if results:
+        first = results[0]
+        print(f"  ID:     {first.get('id')}")
+        print(f"  Title:  {first.get('title')}")
+        print(f"  Source: {first.get('source')}")
+
+    # get_image_details
+    if results:
+        image_id = results[0]["id"]
+        print(f"\nGetting details for image ID: {image_id}")
+        details = _tool_payload(
+            await session.call_tool(
+                "get_image_details", {"image_id": image_id}
             )
-            
-            print("\nImage details:")
-            print(json.dumps(details, indent=2))
-        else:
-            print("No images found to test get_image_details")
-    finally:
-        await session.shutdown()
+        )
+        print("Image details:")
+        print(json.dumps(details, indent=2)[:500])
+
+    # help resource
+    print("\nListing resources...")
+    resources = (await session.list_resources()).resources
+    print(f"Available resources: {[str(r.uri) for r in resources]}")
+    help_result = await session.read_resource("stock-images://help")
+    help_text = help_result.contents[0].text
+    print(f"Help resource retrieved: {len(help_text)} characters")
 
 
-async def test_help_resource():
-    """Test the help resource."""
-    print("\nTesting help resource...")
-    
-    # Create a client session for the local MCP server
-    session = ClientSession("stocky", "http://localhost:8080")
-    await session.initialize()
-    
-    try:
-        # List available resources
-        resources = await session.list_resources()
-        print(f"Available resources: {[r.uri for r in resources]}")
-        
-        # Get the help resource
-        help_text = await session.read_resource("stock-images://help")
-        print(f"Help resource retrieved: {len(help_text)} characters")
-        print("\nFirst 200 characters of help text:")
-        print(help_text[:200] + "...")
-    finally:
-        await session.shutdown()
-
-
-async def main():
-    """Run all tests."""
+async def main() -> int:
     print("Starting Stocky MCP client tests...\n")
-    
-    # Start the server process (in this case, we're using an existing one)
-    server_process = await start_server_process()
-    
+
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=[str(SERVER_PATH)],
+        env=os.environ.copy(),
+    )
+
     try:
-        # Run the tests
-        await test_search_images()
-        await test_get_image_details()
-        await test_help_resource()
-        print("\nAll tests completed!")
-    except Exception as e:
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await run_tests(session)
+    except Exception as e:  # noqa: BLE001 - surface any failure as a test failure
         print(f"\nError during tests: {e}")
-    finally:
-        # We're not terminating the server since we didn't start it
-        pass
+        return 1
+
+    print("\nAll tests completed!")
+    return 0
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
Fixes three open issues. All tests pass with these changes (`test_stocky.py` 19/19, `test_mcp_client.py` exits 0 against a live server).

## #7 — Pexels search returns no results

Three stacked bugs, each masking the next:

1. **Missing `User-Agent` → HTTP 403.** pycurl sends no `User-Agent` by default, and Pexels' Cloudflare rejects such requests. Added a `User-Agent` header to the search and `get_details` requests.
2. **Sync method awaited as a coroutine.** `PexelsProvider.search` / `get_details` were synchronous `def`, but the aggregator (and `test_stocky.py`) call `await provider.search(...)`, raising `'list' object can't be awaited` — caught and swallowed into empty results. Made both methods `async def`, matching `UnsplashProvider`.
3. **Dead code / missing `return`.** The result-building loop was mis-indented inside an `except` block after `return []`, so a successful (HTTP 200) response never built or returned results. Moved the loop into the `try` body and added `return results`.

`UnsplashProvider` was unaffected, which is why only Pexels appeared broken.

## #9 — Tests broken

`test_mcp_client.py` constructed `ClientSession("stocky", "http://localhost:8080")`, but `ClientSession` takes `(read_stream, write_stream)` — the string was then used as a stream and raised `'str' object has no attribute 'send'`. There is also no HTTP endpoint; the server speaks stdio. Rewrote the client to spawn the server via `stdio_client` + `StdioServerParameters`, perform the handshake, list tools, call `search_stock_images` / `get_image_details`, and read the help resource. It exits non-zero on failure so it is CI-usable. (`test_stocky.py` already `await`ed the providers, so it only passes once #7's async fix is in place.)

## #8 — README mentions wrong methods

The tools are MCP tools invoked by the client, not importable Python functions, so examples like `await search_stock_images(...)` were misleading. Reframed the usage section to show natural-language prompts plus the JSON arguments each maps to, and pointed programmatic users at `test_mcp_client.py`. Also corrected the troubleshooting note: the server reads keys from its environment (the client's `env` block), not a `.env` file.

## Testing

```
$ python test_stocky.py
Total tests: 19   Passed: 19   Failed: 0

$ python test_mcp_client.py
Available tools: ['search_stock_images', 'get_image_details', 'download_image']
Found 6 images   (Pexels + Unsplash)
All tests completed!   (exit 0)
```

A `mountain sunset` search through the live MCP server now returns results from both providers (Pexels previously returned 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)