### PR TITLE
docs: add upgrade guidance for existing 1.x users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,66 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Security
-
-- Downloads now refuse any non-image file extension. A download path arrives
-  from a model-generated tool call, so without this the tool could be steered
-  into writing bytes to `~/Library/LaunchAgents/x.plist` or a `.py` on the
-  import path.
-- Image URLs taken from provider responses are validated before being fetched.
-  httpx ignores `base_url` for an absolute URL, so a hostile or compromised
-  response could otherwise point the fetch at `169.254.169.254` or localhost.
-  Private, loopback, link-local and non-HTTP URLs are refused.
-- Image bytes are fetched with a separate, unauthenticated client. The
-  provider client sends the API key on every request, and the image CDN is a
-  different origin that has no business seeing it.
-- Image fetches send `Accept-Encoding: identity`. The size cap was applied to
-  decompressed bytes, so a small gzipped body could expand well past it before
-  the limit was noticed.
-- `request_json` now streams against a size cap. It previously buffered the
-  whole body with no limit, so a ~200 KB compressed response could decode into
-  roughly a gigabyte of memory.
-- Provider-native image ids are validated before being interpolated into a URL
-  path. httpx normalises dot segments, so `unsplash_../../me` reached a
-  different authenticated endpoint on the provider's own API.
-- API keys are excluded from `repr(Config)`, and stripped from provider error
-  messages before they are logged or returned — some APIs echo the rejected
-  credential back.
-- Attribution HTML escapes photographer names and URLs, which are
-  user-supplied content on both providers.
-- Redirects are capped, and the root logger is pinned to stderr so a
-  third-party library cannot corrupt the JSON-RPC stream.
-- The PyPI publish action is pinned by commit rather than the mutable
-  `release/v1` branch, and `persist-credentials: false` is set on checkout.
-
-### Fixed
-
-- **Concurrent tool calls corrupted each other.** One provider instance was
-  shared for the manager's lifetime, and each operation opened and closed its
-  single HTTP client. The first call to finish closed the client out from
-  under the others, which failed with "must be used as an async context
-  manager" — and, for Unsplash, silently skipped the mandatory download
-  report. Provider instances are now created per operation.
-- Cached search payloads were copied shallowly, so a caller mutating a
-  returned result corrupted every later cache hit.
-- Cache keys were built by joining unescaped values, so a colour of
-  `red&orientation=landscape` collided with a genuine filtered search and
-  returned the wrong cached results. All segments are now percent-encoded.
-- A 200 response with an unexpected shape raised `KeyError` out of
-  `get_image_details` and `download_image` instead of returning an error.
-- `NaN` and `inf` in numeric environment variables crashed startup or silently
-  defeated the minimum-value guards, disabling the cache and the HTTP timeout.
-- Unsplash downloads fetched the photo twice — once for metadata and again for
-  the download-report URL — halving the usable budget on their 50-per-hour
-  demo tier. The location now travels on the result.
-- Saving an image to disk omitted the attribution block that the base64 path
-  included, despite saving being exactly what the licences call "taking" the
-  photo.
-- A zero-byte response was reported as a successful download.
-- `per_page` and `page` are normalised before caching and before being echoed,
-  so a cache hit no longer reports a different page than was requested.
-- An empty `providers` list is treated as "all configured" rather than an
-  error, and duplicate provider names no longer issue the same request twice.
+Nothing yet.
 
 ## [2.0.0] — 2026-07-28
 
@@ -93,7 +34,7 @@ working, but several behaviours are deliberately different — see *Changed*.
 - All image size variants are now carried on each result, including the Pexels
   variants that have no canonical equivalent (`large2x`, `portrait`,
   `landscape`).
-- A pytest suite of 204 tests at ~95% coverage, plus opt-in integration tests
+- A pytest suite of 241 tests at ~96% coverage, plus opt-in integration tests
   against the real APIs.
 - `CONTRIBUTING.md` and this changelog.
 
@@ -162,6 +103,38 @@ working, but several behaviours are deliberately different — see *Changed*.
 - The print-based `test_stocky.py` and `test_mcp_client.py` scripts, converted
   into the pytest suite and integration tests.
 - `setup.py`, `setup.cfg`, `requirements.txt`.
+
+### Security
+
+- Downloads now refuse any non-image file extension. A download path arrives
+  from a model-generated tool call, so without this the tool could be steered
+  into writing bytes to `~/Library/LaunchAgents/x.plist` or a `.py` on the
+  import path.
+- Image URLs taken from provider responses are validated before being fetched.
+  httpx ignores `base_url` for an absolute URL, so a hostile or compromised
+  response could otherwise point the fetch at `169.254.169.254` or localhost.
+  Private, loopback, link-local and non-HTTP URLs are refused.
+- Image bytes are fetched with a separate, unauthenticated client. The
+  provider client sends the API key on every request, and the image CDN is a
+  different origin that has no business seeing it.
+- Image fetches send `Accept-Encoding: identity`. The size cap was applied to
+  decompressed bytes, so a small gzipped body could expand well past it before
+  the limit was noticed.
+- `request_json` now streams against a size cap. It previously buffered the
+  whole body with no limit, so a ~200 KB compressed response could decode into
+  roughly a gigabyte of memory.
+- Provider-native image ids are validated before being interpolated into a URL
+  path. httpx normalises dot segments, so `unsplash_../../me` reached a
+  different authenticated endpoint on the provider's own API.
+- API keys are excluded from `repr(Config)`, and stripped from provider error
+  messages before they are logged or returned — some APIs echo the rejected
+  credential back.
+- Attribution HTML escapes photographer names and URLs, which are
+  user-supplied content on both providers.
+- Redirects are capped, and the root logger is pinned to stderr so a
+  third-party library cannot corrupt the JSON-RPC stream.
+- The PyPI publish action is pinned by commit rather than the mutable
+  `release/v1` branch, and `persist-credentials: false` is set on checkout.
 
 [Unreleased]: https://github.com/joelio/stocky/compare/v2.0.0...HEAD
 [2.0.0]: https://github.com/joelio/stocky/releases/tag/v2.0.0

--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ Stocky is an [MCP](https://modelcontextprotocol.io) server that lets an AI
 assistant search, inspect and download royalty-free stock photography from
 **Pexels** and **Unsplash**.
 
+> ### 🆕 Version 2.0 — already using Stocky? Read this
+>
+> **Your MCP client config keeps working.** If it points at `stocky_mcp.py`,
+> that file is still there and still starts the server. Nothing breaks on
+> upgrade.
+>
+> **But `pip install -r requirements.txt` will fail** — that file is gone, and
+> so is `setup.py`. From a source checkout, install with **`uv sync`** or
+> **`pip install -e .`** instead. See [Upgrading from 1.x](#upgrading)
+> for the two-minute version, or the [CHANGELOG](CHANGELOG.md) for everything.
+>
+> The headline changes: `pycurl` is gone (so no more C build errors),
+> searches actually run concurrently, failed providers now report *why*
+> instead of returning nothing, and Python 3.10+ is required.
+
 ## ✨ Features
 
 - 🔍 **Multi-provider search** — queries Pexels and Unsplash concurrently
@@ -106,6 +121,8 @@ working:
 Stocky reads its configuration from the environment its client starts it in.
 It does not load a `.env` file of its own, so keys must go in the `env` block
 above.
+
+<a id="configuration"></a>
 
 ## ⚙️ Configuration
 
@@ -211,6 +228,81 @@ block with ready-made `text` and `html` in the correct format for its provider.
 
 Read the full terms: [Pexels](https://www.pexels.com/api/documentation/) ·
 [Unsplash](https://help.unsplash.com/en/articles/2511245-unsplash-api-guidelines)
+
+<a id="upgrading"></a>
+
+## ⬆️ Upgrading from 1.x
+
+Version 2.0 restructured the project. **Existing MCP client configurations keep
+working** — the root `stocky_mcp.py` is deliberately retained as a launcher —
+but installation changed, and a few behaviours are intentionally different.
+
+### What you need to do
+
+**If you run it via `uvx` or an installed console script**, nothing. Upgrade
+and carry on.
+
+**If you run it from a source checkout**, reinstall. `requirements.txt`,
+`setup.py` and `setup.cfg` were replaced by `pyproject.toml`:
+
+```bash
+git pull
+uv sync                     # or: pip install -e .
+```
+
+`pip install -r requirements.txt` now fails — the file no longer exists.
+
+**Check your Python version.** 2.0 requires **Python 3.10+**. The old
+`setup.py` claimed 3.8 support, but the `mcp` SDK has always required 3.10, so
+that claim was never actually satisfiable.
+
+**Consider switching to `uvx`.** It needs nothing installed and avoids the
+whole class of "which interpreter did my editor launch?" startup failures:
+
+```json
+{
+  "mcpServers": {
+    "stocky": {
+      "command": "uvx",
+      "args": ["stocky-mcp"],
+      "env": { "PEXELS_API_KEY": "your_pexels_key" }
+    }
+  }
+}
+```
+
+### What changed underneath
+
+| Change | Why it matters to you |
+|---|---|
+| `pycurl` → `httpx` | No C extension to compile, so no more build failures on install. `httpx` was already required by the `mcp` SDK, so this **removed** a dependency. |
+| Searches now run concurrently | The old code was `async` in name only — it made blocking calls inside `async def`. Searching both providers now costs roughly one provider's latency. |
+| Failed providers report why | Previously an invalid API key returned an empty list, identical to a search that genuinely matched nothing. |
+| `per_page` clamped per provider | Unsplash silently falls back to 10 above its maximum of 30, so asking for 50 used to return *fewer* images than asking for 30. |
+| Attribution generated for you | Both providers require it as a condition of API access. Set `ENABLE_ATTRIBUTION_LINKS=true` and every result carries ready-made text and HTML. |
+| New configuration options | Caching, timeouts, download size caps and a download root — see [Configuration](#configuration). |
+
+### The one thing that might affect your code
+
+**Only if you parse Stocky's responses programmatically.** A search that fails
+now returns an `errors` map naming the provider and the reason, where it used
+to return an empty result list:
+
+```jsonc
+{
+  "query": "mountains",
+  "results": { "pexels": [], "unsplash": [ /* ... */ ] },
+  "errors": { "pexels": "pexels rejected the API key (HTTP 401)..." }
+}
+```
+
+If you treated "empty" as "no matches", check for `errors` too — otherwise a
+broken key looks like a query with no results. This is the fix, not a
+regression, but it is a visible change.
+
+Nothing else in the tool surface changed: `search_stock_images`,
+`get_image_details` and `download_image` take the same arguments they always
+did, so existing prompts and workflows are unaffected.
 
 ## 🧑‍💻 Development
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -61,6 +61,6 @@ than a useful error.
 
 ## Environment variables
 
-See the configuration table in the [main README](../README.md#️-configuration).
+See the configuration table in the [main README](../README.md#configuration).
 `STOCKY_DOWNLOAD_ROOT` is worth setting — download paths come from
 model-generated tool calls, and it confines writes to one directory.


### PR DESCRIPTION
Existing MCP client configs keep working after 2.0, but anyone installing from a source checkout hits `pip install -r requirements.txt` failing with no hint about what replaced it.

Adds two things:

- **A callout at the top of the README** for people who already run Stocky — what still works, what breaks, and the one command that fixes it.
- **An "Upgrading from 1.x" section** covering the install change, the Python 3.10 floor (the old `setup.py` claimed 3.8, which was never satisfiable since the `mcp` SDK requires 3.10), and the one behaviour change that can affect callers: a failed provider now returns an `errors` map where it previously returned an empty result list. If you treated "empty" as "no matches", a broken key used to be invisible.

Every claim in the new section was verified against `main` rather than written from memory — the shim still completes a handshake, the three removed files are genuinely gone, and the `errors` payload example matches real output.

Two tidy-ups while in there:

- **Explicit HTML anchors** for the linked sections. GitHub's generated ids for emoji headings retain the U+FE0F variation selector, so `#-configuration` style fragments are unreliable.
- **Folded the CHANGELOG's `Unreleased` section into `2.0.0`.** Nothing has been tagged or released and `__version__` is already `2.0.0`, so the split was misleading for anyone following the new README link. Also corrected the test count from 204 to 241.

Docs only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Version 2.0 installation, compatibility, behavior, and upgrade guidance.
  * Documented Python 3.10+ support requirements and updated installation commands.
  * Clarified concurrent searches, provider errors, response changes, and configuration links.
  * Updated changelog release details and test-suite count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->